### PR TITLE
Remove 'using namespace std' at global scope from orfanidis_eq.h

### DIFF
--- a/src/calf/modules_filter.h
+++ b/src/calf/modules_filter.h
@@ -85,7 +85,7 @@ public:
     bool get_graph(int index, int subindex, int phase, float *data, int points, cairo_iface *context, int *mode) const;
     bool get_layers(int index, int generation, unsigned int &layers) const;
     float freq_gain(int index, double freq) const;
-    string get_crosshair_label(int x, int y, int sx, int sy, float q, int dB, int name, int note, int cents) const;
+    std::string get_crosshair_label(int x, int y, int sx, int sy, float q, int dB, int name, int note, int cents) const;
 
     void set_sample_rate(uint32_t sr)
     {

--- a/src/calf/orfanidis_eq.h
+++ b/src/calf/orfanidis_eq.h
@@ -4,8 +4,6 @@
 #include <math.h>
 #include <vector>
 
-using namespace std;
-
 namespace orfanidis_eq {
 
 //Eq data types.

--- a/src/modules_filter.cpp
+++ b/src/modules_filter.cpp
@@ -498,7 +498,7 @@ float equalizerNband_audio_module<BaseClass, has_lphp>::freq_gain(int index, dou
 }
 
 template<class BaseClass, bool has_lphp>
-inline string equalizerNband_audio_module<BaseClass, has_lphp>::get_crosshair_label(int x, int y, int sx, int sy, float q, int dB, int name, int note, int cents) const
+inline std::string equalizerNband_audio_module<BaseClass, has_lphp>::get_crosshair_label(int x, int y, int sx, int sy, float q, int dB, int name, int note, int cents) const
 { 
     return frequency_crosshair_label(x, y, sx, sy, q, dB, name, note, cents, 128 * *params[AM::param_zoom], 0);
 }


### PR DESCRIPTION
Removes the `using namespace std` directive from global scope in orfanidis_eq.h and prepends usages of std::string with the `std::` prefix.