### PR TITLE
MSVC: Always use Win32 ANSI functions

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -172,8 +172,8 @@ file_exception::file_exception(const std::string &f, const std::string &t)
 vector <direntry> list_directory(const string &path)
 {
 	std::vector <direntry> out;
-	WIN32_FIND_DATA data;
-	HANDLE hFind = FindFirstFile((path+"\\").c_str(), &data);      // DIRECTORY
+	WIN32_FIND_DATAA data;
+	HANDLE hFind = FindFirstFileA((path+"\\").c_str(), &data);      // DIRECTORY
 	if (hFind != INVALID_HANDLE_VALUE)
 	{
 		do
@@ -183,7 +183,7 @@ vector <direntry> list_directory(const string &path)
 			f.full_path = path + "\\" + data.cFileName;
 			f.name = data.cFileName;
 			out.push_back(f);
-		} while (FindNextFile(hFind, &data) != 0);
+		} while (FindNextFileA(hFind, &data) != 0);
 	}
 	FindClose(hFind);
 	return out;


### PR DESCRIPTION
No functional changes here, but allows building veal regardless of whether the `UNICODE` macro is defined